### PR TITLE
Off sites links fix

### DIFF
--- a/local/php_interface/include/classes/codecraft/helpers/languagelink.php
+++ b/local/php_interface/include/classes/codecraft/helpers/languagelink.php
@@ -13,10 +13,10 @@ class LanguageLink
             $path = $APPLICATION->GetCurPageParam();
         }
 
-        $offSites = !(strpos($path, '/'.$languageFrom.'/') === 0);
+        $isOffSites = !(strpos($path, '/'.$languageFrom.'/') === 0);
 
         return ($withHost ? $protocol . $_SERVER['SERVER_NAME'] : '') .
-               ($offSites ? '/' . $languageTo . $path : str_replace('/' . $languageFrom . '/', '/' . $languageTo . '/', $path));
+               ($isOffSites ? '/' . $languageTo . $path : str_replace('/' . $languageFrom . '/', '/' . $languageTo . '/', $path));
     }
 
     public static function setAlternateHeader($languageTo, $languageFrom = false, $path = '') {

--- a/local/php_interface/include/classes/codecraft/helpers/languagelink.php
+++ b/local/php_interface/include/classes/codecraft/helpers/languagelink.php
@@ -13,8 +13,10 @@ class LanguageLink
             $path = $APPLICATION->GetCurPageParam();
         }
 
-        return ($withHost ? $protocol . $_SERVER['SERVER_NAME'] : '') . (!$languageFrom ? '/' . $languageTo . '/' . $path
-            : str_replace('/' . $languageFrom . '/', '/' . $languageTo . '/', $path));
+        $offSites = !(strpos($path, '/'.$languageFrom.'/') === 0);
+
+        return ($withHost ? $protocol . $_SERVER['SERVER_NAME'] : '') .
+               ($offSites ? '/' . $languageTo . $path : str_replace('/' . $languageFrom . '/', '/' . $languageTo . '/', $path));
     }
 
     public static function setAlternateHeader($languageTo, $languageFrom = false, $path = '') {


### PR DESCRIPTION
$languageFrom is often LANGUAGE_ID constant, that always defined as site-default language. It means method called from non-site area returns wrong site-lang path.
