### PR TITLE
Hot fix (constructor fixed)

### DIFF
--- a/local/components/codecraft/null/class.php
+++ b/local/components/codecraft/null/class.php
@@ -31,7 +31,7 @@ class CCodeCraftNullComponent extends \CBitrixComponent {
      * @param  array[string]mixed $arParams
      * @return array[string]mixed
      */
-    public static function onPrepareComponentParams($params) {
+    public function onPrepareComponentParams($params) {
         return $params;
     }
 


### PR DESCRIPTION
Method "onPrepareComponentParams" was a static. but parent method is not static. Fixed.

By pandmitr
